### PR TITLE
Allow to publish to remote servers

### DIFF
--- a/static/publish-embed.js
+++ b/static/publish-embed.js
@@ -59,7 +59,7 @@ require(['dw/chart/publish'], function() {
                 }
 
                 $.ajax({
-                    url: '/api/charts/' + chart_id + '/publish?local=1',
+                    url: '/api/charts/' + chart_id + '/publish',
                     type: 'post'
                 }).done(function() {
                     callback(null);


### PR DESCRIPTION
With the `?local=1` param the deploys are only local, we need to be able to deploy to a CDN!